### PR TITLE
Update cs314.checkstyle.xml

### DIFF
--- a/cs314.checkstyle.xml
+++ b/cs314.checkstyle.xml
@@ -166,6 +166,7 @@
     <module name="MethodLength">
       <property name="tokens" value="METHOD_DEF"/>
       <property name="max" value="25"/>
+      <property name="countEmpty" value="false"/>
     </module>
     <module name="MethodName"/>
     <module name="MethodParamPad"/>
@@ -231,10 +232,6 @@
     <module name="Regexp">
       <property name="format" value="[Ss]ection 5 [Dd]igit [Ii][Dd]: \d{5}"/>
       <property name="message" value="Make sure you have your header comment with your section number!" />
-    </module>
-    <module name="Regexp">
-      <property name="format" value="[Ee]mail( [Aa]ddress)?: (.)+@utexas.edu"/>
-      <property name="message" value="Make sure you have your header comment with your UTexas.edu email!" />
     </module>
     <module name="Regexp">
       <property name="format" value="[Ee]mail( [Aa]ddress)?: (.)+@utexas.edu"/>


### PR DESCRIPTION
Removed redundant email check. Added method length exclusion for blank lines, so the 25 line count is for actual lines of code, not spacing.